### PR TITLE
Modify script.js to generate chart with monthly income vs. expense data

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/IncomeExpenseServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/IncomeExpenseServlet.java
@@ -5,11 +5,9 @@ import com.google.sps.data.MonthData;
 import com.google.sps.data.Transaction;
 import com.opencsv.CSVReader;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -31,16 +29,15 @@ import javax.servlet.http.Part;
 @MultipartConfig
 public class IncomeExpenseServlet extends HttpServlet {
 
-  private Map<YearMonth, MonthData> IncomeExpenseGraph = new HashMap<>();
+  private Map<YearMonth, MonthData> IncomeExpenseChart = new HashMap<>();
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    /*
+    // Respond to GET request by returning JSON of income/expense data
     response.setContentType("application/json");
     Gson gson = new Gson();
-    String json = gson.toJson(colorVotes);
+    String json = gson.toJson(IncomeExpenseChart);
     response.getWriter().println(json);
-    */
   }
 
   @Override
@@ -60,31 +57,28 @@ public class IncomeExpenseServlet extends HttpServlet {
       transactions.add(new Transaction(
           LocalDate.parse(nextLine[0]), nextLine[1], Float.parseFloat(nextLine[2])));
     }
-    // For each transaction in array, get YearMonth and add to IncomeExpenseGraph map
+    // For each transaction in array, get YearMonth and add to IncomeExpenseChart map
     ListIterator<Transaction> itr = transactions.listIterator();
     while (itr.hasNext()) {
       Transaction transaction = itr.next();
       YearMonth month = YearMonth.from(transaction.getDate());
       // Add new YearMonth key if not already in map
-      IncomeExpenseGraph.putIfAbsent(month, new MonthData());
+      IncomeExpenseChart.putIfAbsent(month, new MonthData());
       // Add to income if transaction has positive amount, expense if negative amount
       if (transaction.getAmount() > 0) {
-        IncomeExpenseGraph.get(month).addIncome(transaction.getAmount());
+        IncomeExpenseChart.get(month).addIncome(transaction.getAmount());
       } else {
-        IncomeExpenseGraph.get(month).addExpense(-1 * transaction.getAmount());
+        IncomeExpenseChart.get(month).addExpense(-1 * transaction.getAmount());
       }
     }
-
-    for (YearMonth month : IncomeExpenseGraph.keySet()) {
-      System.out.println(month + ": " + IncomeExpenseGraph.get(month));
-    }
-
+    // Print monthly data to console for testing
     /*
-    String color = request.getParameter("color");
-    int currentVotes = colorVotes.containsKey(color) ? colorVotes.get(color) : 0;
-    colorVotes.put(color, currentVotes + 1);
-
-    response.sendRedirect("income-expense.html");
+    for (YearMonth month : IncomeExpenseChart.keySet()) {
+      System.out.println(month + ": " + IncomeExpenseChart.get(month));
+    }
     */
+    
+    // Redirect to income vs. expense page
+    response.sendRedirect("income-expense.html"); 
   }
 }

--- a/portfolio/src/main/webapp/income-expense.html
+++ b/portfolio/src/main/webapp/income-expense.html
@@ -2,17 +2,54 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Income vs. Expense</title>
     <link rel="stylesheet" href="style.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <script src="script.js"></script>
   </head>
   <body>
+    <!--Navbar code-->
+    <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd;">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">BetterBudget</a> <!--Back to home page-->
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="index.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="income-expense.html">Income vs. Expense</a> <!--To income expenses calcualtor-->
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="emergencyFund.html">Emergency Fund</a> <!--To Emergency Fund Calculator-->
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#"> Rent vs. Buy</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    
     <div id="content">
       <h1>Income vs. Expense Calculator</h1>
       <form action="/process-income-expense" method="POST" enctype="multipart/form-data">
-        <input type="file" accept=".csv, text/csv" name="file"/>
-        <input type="submit"/>
+        <p>
+          When setting a budget, it's important to know how much money you actually make. 
+          <strong>Income</strong> is any money you regularly earn each month. Usually it comes from your job but it can come from other sources like the government. These are positive transactions in your bank account.
+          <strong>Expenses</strong> are money you spend each month. This includes paying for your rent or mortgage, utilities, groceries, gas, subscriptions, and entertainment. These are negative transactions in your bank account.
+          <strong>Cash Flow</strong> is income minus expenses. This is how much money you're actually making each month. Watch out for negative cash flow! This means you're spending more money than you have.
+        </p>
+        <h4>Upload a CSV with transactions to see how much you make each month</h4>
+        <p>Use the following format: Date, Description, Amount</p>
+        <input type="file" accept=".csv, text/csv" name="file" id="csvFile"/>
+        <button type="submit">Generate Chart!</button>
       </form>
       <div id="income-expense-chart"></div>
     </div>

--- a/portfolio/src/main/webapp/income-expense.html
+++ b/portfolio/src/main/webapp/income-expense.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Income vs. Expense</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
     <script src="script.js"></script>
   </head>
   <body>
@@ -13,6 +14,7 @@
         <input type="file" accept=".csv, text/csv" name="file"/>
         <input type="submit"/>
       </form>
+      <div id="income-expense-chart"></div>
     </div>
   </body>
 </html>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -15,30 +15,38 @@
 google.charts.load('current', {'packages':['corechart']});
 google.charts.setOnLoadCallback(drawIncomeExpenseChart);
 
-/** Fetches color data and uses it to create a chart. */
+/** Fetches monthly income/expense data and uses it to create a chart. */
 function drawIncomeExpenseChart() {
   fetch('/process-income-expense').then(response => response.json())
-  .then(data => console.log(data));
-  /*
-  .then((colorVotes) => {
+  .then((incomeExpenseData) => {
+    console.log(incomeExpenseData);
     const data = new google.visualization.DataTable();
-    data.addColumn('string', 'Color');
-    data.addColumn('number', 'Votes');
-    Object.keys(colorVotes).forEach((color) => {
-      data.addRow([color, colorVotes[color]]);
+
+    // Display income, expense, and cash flow for each month
+    data.addColumn('string', 'Month');
+    data.addColumn('number', 'Income');
+    data.addColumn('number', 'Expense');
+    data.addColumn('number', 'Cash Flow');
+
+    // For each month in income/expense data object
+    Object.keys(incomeExpenseData).forEach((month) => {
+      // Add row with income, expense, and cashflow
+      const income = incomeExpenseData[month].income;
+      const expense = incomeExpenseData[month].expense;
+      const cashFlow = income - expense;
+      data.addRow([month, income, expense, cashFlow]);
     });
 
     const options = {
-      'title': 'Favorite Colors',
+      'title': 'Income vs. Expense by Month',
       'width':600,
       'height':500
     };
 
     const chart = new google.visualization.ColumnChart(
-        document.getElementById('chart-container'));
+        document.getElementById('income-expense-chart'));
     chart.draw(data, options);
   });
-  */
 }
 
 /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -12,6 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+google.charts.load('current', {'packages':['corechart']});
+google.charts.setOnLoadCallback(drawIncomeExpenseChart);
+
+/** Fetches color data and uses it to create a chart. */
+function drawIncomeExpenseChart() {
+  fetch('/process-income-expense').then(response => response.json())
+  .then(data => console.log(data));
+  /*
+  .then((colorVotes) => {
+    const data = new google.visualization.DataTable();
+    data.addColumn('string', 'Color');
+    data.addColumn('number', 'Votes');
+    Object.keys(colorVotes).forEach((color) => {
+      data.addRow([color, colorVotes[color]]);
+    });
+
+    const options = {
+      'title': 'Favorite Colors',
+      'width':600,
+      'height':500
+    };
+
+    const chart = new google.visualization.ColumnChart(
+        document.getElementById('chart-container'));
+    chart.draw(data, options);
+  });
+  */
+}
+
 /**
  * Adds a random greeting to the page.
  */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -19,11 +19,10 @@ google.charts.setOnLoadCallback(drawIncomeExpenseChart);
 function drawIncomeExpenseChart() {
   fetch('/process-income-expense').then(response => response.json())
   .then((incomeExpenseData) => {
-    console.log(incomeExpenseData);
     const data = new google.visualization.DataTable();
 
     // Display income, expense, and cash flow for each month
-    data.addColumn('string', 'Month');
+    data.addColumn('date', 'Month');
     data.addColumn('number', 'Income');
     data.addColumn('number', 'Expense');
     data.addColumn('number', 'Cash Flow');
@@ -34,13 +33,19 @@ function drawIncomeExpenseChart() {
       const income = incomeExpenseData[month].income;
       const expense = incomeExpenseData[month].expense;
       const cashFlow = income - expense;
-      data.addRow([month, income, expense, cashFlow]);
+      data.addRow([new Date(month), income, expense, cashFlow]);
     });
 
     const options = {
       'title': 'Income vs. Expense by Month',
-      'width':600,
-      'height':500
+      'width':800,
+      'height':500,
+      'hAxis':{
+        'format': 'MMM y',
+        'gridlines': {'color': 'none'}
+      },
+      'vAxis': {'format': 'currency'},
+      'titleTextStyle': {'fontSize': 16}
     };
 
     const chart = new google.visualization.ColumnChart(

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -19,38 +19,40 @@ google.charts.setOnLoadCallback(drawIncomeExpenseChart);
 function drawIncomeExpenseChart() {
   fetch('/process-income-expense').then(response => response.json())
   .then((incomeExpenseData) => {
-    const data = new google.visualization.DataTable();
+    // if CSV data has been submitted, create chart
+    if (Object.keys(incomeExpenseData).length !== 0) {
+      const data = new google.visualization.DataTable();
+      // Display income, expense, and cash flow for each month
+      data.addColumn('date', 'Month');
+      data.addColumn('number', 'Income');
+      data.addColumn('number', 'Expense');
+      data.addColumn('number', 'Cash Flow');
 
-    // Display income, expense, and cash flow for each month
-    data.addColumn('date', 'Month');
-    data.addColumn('number', 'Income');
-    data.addColumn('number', 'Expense');
-    data.addColumn('number', 'Cash Flow');
+      // For each month in income/expense data object
+      Object.keys(incomeExpenseData).forEach((month) => {
+        // Add row with income, expense, and cashflow
+        const income = incomeExpenseData[month].income;
+        const expense = incomeExpenseData[month].expense;
+        const cashFlow = income - expense;
+        data.addRow([new Date(month), income, expense, cashFlow]);
+      });
 
-    // For each month in income/expense data object
-    Object.keys(incomeExpenseData).forEach((month) => {
-      // Add row with income, expense, and cashflow
-      const income = incomeExpenseData[month].income;
-      const expense = incomeExpenseData[month].expense;
-      const cashFlow = income - expense;
-      data.addRow([new Date(month), income, expense, cashFlow]);
-    });
+      const options = {
+        'title': 'Income vs. Expense by Month',
+        'width':800,
+        'height':500,
+        'hAxis':{
+          'format': 'MMM y',
+          'gridlines': {'color': 'none'}
+        },
+        'vAxis': {'format': 'currency'},
+        'titleTextStyle': {'fontSize': 16}
+      };
 
-    const options = {
-      'title': 'Income vs. Expense by Month',
-      'width':800,
-      'height':500,
-      'hAxis':{
-        'format': 'MMM y',
-        'gridlines': {'color': 'none'}
-      },
-      'vAxis': {'format': 'currency'},
-      'titleTextStyle': {'fontSize': 16}
-    };
-
-    const chart = new google.visualization.ColumnChart(
-        document.getElementById('income-expense-chart'));
-    chart.draw(data, options);
+      const chart = new google.visualization.ColumnChart(
+          document.getElementById('income-expense-chart'));
+      chart.draw(data, options);
+    }
   });
 }
 


### PR DESCRIPTION
First I modified the doGet() function in IncomeExpenseServlet.java to send the income/expense data generated by doPost() as a JSON string to the client. Then, I used the favorite-colors example from the charts library walkthrough as reference for creating the drawIncomeExpenseChart() function in script.js. When the Income vs. Expense page loads, drawIncomeExpenseChart() fetches the data from the servlet and creates a Google Charts data table with the month, income, expense, and cashflow.

I printed the JSON object from the servlet to the console for testing:
<img width="632" alt="Screen Shot 2022-07-19 at 4 58 55 PM" src="https://user-images.githubusercontent.com/52755071/179867701-08523d73-e7c2-47a0-aac7-416552768b5f.png">

Index vs. Expense page with column chart
<img width="675" alt="Screen Shot 2022-07-19 at 4 59 47 PM" src="https://user-images.githubusercontent.com/52755071/179867784-7db1027f-2f6b-4d73-a5f2-289a925eeff1.png">
